### PR TITLE
Module Icon not working

### DIFF
--- a/PrivacyWire.module
+++ b/PrivacyWire.module
@@ -30,7 +30,7 @@ class PrivacyWire extends WireData implements Module, ConfigurableModule
             'singular' => true,
             'requires' => [ "PHP>=7.2", "ProcessWire>=3.0.110" ],
             'installs' => [ "TextformatterPrivacyWire" ],
-            'icon' => 'cookie'
+            'icon' => 'eye-slash'
         ];
     }
 


### PR DESCRIPTION
PW with UIKIT uses FontAwesome 4 icons - there's no "cookie" icon :-/ so I've changed it to "eye-slash".