### PR TITLE
Use Rollup recommendation to avoid warning

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -22,6 +22,7 @@ export default [
       }),
       babel({
         exclude: 'node_modules/**',
+        babelHelpers: 'bundled',
       }),
       production && terser()
     ],
@@ -40,6 +41,7 @@ export default [
       }),
       babel({
         exclude: 'node_modules/**',
+        babelHelpers: 'bundled',
       }),
       production && terser()
     ],


### PR DESCRIPTION
From https://github.com/rollup/plugins/tree/master/packages/babel#babelhelpers:

"
[...] It is recommended to configure this option explicitly (even if with its default value) so an informed decision is taken on how those babel helpers are inserted into the code. [...] as Rollup is a bundler and is project-aware (and therefore likely operating across multiple input files), the default of this plugin is "bundled". [...]
"