### PR TITLE
Feature: manual rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog of PrivacyWire
 
+## 0.3.6
+- Added: Config option to prevent automatic rendering.
+- Added: New methods renderHeadContent() and renderBodyContent().
+
 ## 0.3.4
 - Fixed: sanitize alternative banner template path to ignore leading slash
 

--- a/PrivacyWire.module
+++ b/PrivacyWire.module
@@ -25,7 +25,7 @@ class PrivacyWire extends WireData implements Module, ConfigurableModule
             'summary' => "This module adds management options for GDPR-relevant elements (loading maps, videos etc. only after accepting external media) and cookies.",
             'author' => "blaueQuelle",
             'href' => "https://github.com/blaueQuelle/privacywire",
-            'version' => 35,
+            'version' => 36,
             'autoload' => true,
             'singular' => true,
             'requires' => ["PHP>=7.2", "ProcessWire>=3.0.110"],
@@ -43,7 +43,9 @@ class PrivacyWire extends WireData implements Module, ConfigurableModule
             return;
         }
 
-        $this->addHookAfter('Page::render', $this, 'render');
+        if (!$this->render_manually) {
+            $this->addHookAfter('Page::render', $this, 'render');
+        }
     }
 
     /**
@@ -96,12 +98,23 @@ class PrivacyWire extends WireData implements Module, ConfigurableModule
 
     public function ___render(HookEvent $event)
     {
-        $headContent = "<script>var PrivacyWireSettings={$this->getInlineJs()};</script>";
-        $headContent .= ($this->use_procache_minification && $this->wire('modules')->isInstalled('ProCache') && $this->wire('modules')->get('ProCache')) ? "<script defer src='{$this->wire('modules')->get('ProCache')->js($this->getJsFile())}'></script>" : "<script defer src='{$this->getJsFile()}'></script>";
+        $headContent = $this->renderHeadContent();
         $event->return = str_replace("</head>", "{$headContent}</head>", $event->return);
 
-        $bodyContent = wireRenderFile($this->getBannerTemplateFile(), ['module' => $this]);
+        $bodyContent = $this->renderBodyContent();
         $event->return = str_replace("</body>", "{$bodyContent}</body>", $event->return);
+    }
+
+    public function renderHeadContent()
+    {
+        $headContent = "<script>var PrivacyWireSettings={$this->getInlineJs()};</script>";
+        $headContent .= ($this->use_procache_minification && $this->wire('modules')->isInstalled('ProCache') && $this->wire('modules')->get('ProCache')) ? "<script defer src='{$this->wire('modules')->get('ProCache')->js($this->getJsFile())}'></script>" : "<script defer src='{$this->getJsFile()}'></script>";
+        return $headContent;
+    }
+
+    public function renderBodyContent()
+    {
+        return wireRenderFile($this->getBannerTemplateFile(), ['module' => $this]);
     }
 
     public function ___install()

--- a/PrivacyWireConfig.php
+++ b/PrivacyWireConfig.php
@@ -34,7 +34,8 @@ class PrivacyWireConfig extends ModuleConfig
             'ask_consent_message' => $this->_("To load this element, it is required to consent to the following cookie category: {category}."),
             'ask_content_button_label' => $this->_("Load {category} cookies"),
             'banner_header_tag' => 'header',
-            'alternate_banner_template' => ''
+            'alternate_banner_template' => '',
+            'render_manually' => false,
         ];
     }
 
@@ -335,6 +336,14 @@ class PrivacyWireConfig extends ModuleConfig
         $f->label = $this->_('Alternate Banner Template');
         $f->description = $this->_("If you want to replace the original banner template (located in site/modules/PrivacyWire/PrivacyWireBanner.php ) insert the alternative file path here (starting from webroot without leading slash )");
         $f->columnWidth = 34;
+        $content->add($f);
+
+        // render manually
+        $f = $this->modules->get('InputfieldCheckbox');
+        $f->attr('name', 'render_manually');
+        $f->label = $this->_('Render Banner and Header Content Manually');
+        $f->description = $this->_("If you want to render PrivacyWire header and banner content manually instead of letting the module render them for you, check this option.");
+        $f->notes = $this->_("Use `\$modules->get('PrivacyWire')->renderHeadContent()` to render header tags and `\$modules->get('PrivacyWire')->renderBodyContent()` to render body content.");
         $content->add($f);
 
         return $inputfields;


### PR DESCRIPTION
Hey @blaueQuelle!

This PR is related to a feature I've been missing. Basically I'm having a bit of problem with rendering PrivacyWire banner to exactly the right position in the DOM, as well as only rendering it for templates where it makes sense.

What I'm suggesting in this PR would be:

- A new option to disable automatic rendering (checkbox render_manually, defaults to false)
- Two new PrivacyWire module methods: renderHeadContent() and renderBodyContent()

What do you think, does this make sense to you?

Please note that I've only briefly tested this — seems to work so far, but even if you think this feature makes sense, it would be a good idea to test it a bit more... :)