### PR TITLE
Add support for replacing embedded media with TextformatterPrivacyWire

### DIFF
--- a/TextformatterPrivacyWire.module
+++ b/TextformatterPrivacyWire.module
@@ -25,7 +25,7 @@ class TextformatterPrivacyWire extends Textformatter implements Module
             'summary' => "PrivacyWire Textformatter to render privacy options via shortcode [[privacywire-choose-cookies]]",
             'author' => 'blaueQuelle',
             'href' => "https://github.com/blaueQuelle/privacywire",
-            'version' => 7,
+            'version' => 8,
             'requires' => [
                 "PHP>=7.2",
                 "ProcessWire>=3.0.110"
@@ -35,20 +35,31 @@ class TextformatterPrivacyWire extends Textformatter implements Module
 
     public function formatValue(Page $page, Field $field, &$str)
     {
-        $privacyWire = $this->modules->get("PrivacyWire");
+        // Replace privacywire-choose-cookies with button element
+        $tag_search = $this->open_tag . "privacywire-choose-cookies" . $this->close_tag;
+        if (strpos($str, $tag_search) !== false) {
+            $privacyWire = $this->modules->get("PrivacyWire");
 
-        // Multi Language Support
-        if ($this->wire('languages')) {
-            $userLanguage = $this->wire('user')->language;
-            $lang = $userLanguage->isDefault() ? '' : "__$userLanguage->id";
-        } else {
-            $lang = '';
+            // Multi Language Support
+            if ($this->wire('languages')) {
+                $userLanguage = $this->wire('user')->language;
+                $lang = $userLanguage->isDefault() ? '' : "__$userLanguage->id";
+            } else {
+                $lang = '';
+            }
+
+            $tag_replace = "<button class='button privacywire-show-options'>{$privacyWire->get("textformatter_choose_label$lang|textformatter_choose_label")}</button>";
+            $str = str_replace($tag_search, $tag_replace, $str);
         }
 
-        $tag_search = $this->open_tag . "privacywire-choose-cookies" . $this->close_tag;
-
-        $tag_replace = "<button class='button privacywire-show-options'>{$privacyWire->get("textformatter_choose_label$lang|textformatter_choose_label")}</button>";
-
-        $str = str_replace($tag_search, $tag_replace, $str);
+        // Optional: enable PrivacyWire support for embedded media
+        if ($this->video_category && strpos($str, 'www.youtube.com/embed/') !== false) {
+            if (preg_match_all('/\<iframe.*?src=("|\')(?:https?:)\/\/(?:www\.youtube|player\.vimeo)\..*?\1.*?\<\/iframe\>/is', $str, $matches)) {
+                foreach ($matches[0] as $match) {
+                    $new_match = str_replace(' src=', ' data-category="' . $this->video_category . '" data-ask-consent=1 data-src=', $match);
+                    $str = str_replace($match, $new_match, $str);
+                }
+            }
+        }
     }
 }

--- a/TextformatterPrivacyWireConfig.php
+++ b/TextformatterPrivacyWireConfig.php
@@ -7,6 +7,7 @@ class TextformatterPrivacyWireConfig extends ModuleConfig
         return [
             'open_tag' => '[[',
             'close_tag' => ']]',
+            'video_category' => null,
         ];
     }
 
@@ -27,6 +28,26 @@ class TextformatterPrivacyWireConfig extends ModuleConfig
         $f->label = $this->_('Close Tag');
         $f->columnWidth = 50;
         $inputfields->add($f);
+
+        // embedded media
+        $fs = $this->modules->get('InputfieldFieldset');
+        $fs->attr('name', 'embedded_media');
+        $fs->label = $this->_('Embedded media');
+        $inputfields->add($fs);
+
+        // category for embedded videos (optional)
+        $f = $this->modules->get('InputfieldSelect');
+        $f->attr('name', 'video_category');
+        $f->label = $this->_('Category for embedded videos');
+        $f->description = $this->_('If you select a category here, users will need to accept said cookie category before embedded video elements are displayed. Leave empty to disable this feature.');
+        $f->notes = $this->_('Recommended if you\'re using [TextformatterVideoEmbed](https://processwire.com/modules/textformatter-video-embed/). Note that TextformatterPrivacyWire need to run after TextformatterVideoEmbed for this to work.');
+        $f->columnWidth = 50;
+        $f->options = [
+            "statistics" => $this->_("Statistics"),
+            'marketing' => $this->_("Marketing"),
+            'external_media' => $this->_("External Media")
+        ];
+        $fs->add($f);
 
         return $inputfields;
     }


### PR DESCRIPTION
This is somewhat opinionated, but to sum it up:

- In almost all sites I've built I'm using TextformatterVideoEmbed to allow embedding videos from YouTube/Vimeo. The problem with these is that both services use cookies and/or LocalStorage.
- This PR adds additional capability to TextformatterPrivacyWire, enabling it to replace embedded YouTube/Vimeo iframes on the fly with PrivacyWire-enabled ones (i.e. replacing src with data-src and adding data-category and data-ask-consent=1).

While PrivacyWire has cookie category for external media, this is actually not what I usually use, so instead of just adding a toggle checkbox or making this behaviour automatic I've added a category select to module config: if that's populated, the module will use that category — otherwise it'll leave iframes alone.

I've also made some very minor tweaks to the formatValue() method, just so that it doesn't do anything unnecessary.

<img width="1201" alt="Screenshot 2020-11-19 at 17 54 30" src="https://user-images.githubusercontent.com/1252021/99690016-51257a80-2a90-11eb-997d-5a7c1144ac4b.png">

Let me know if you'd rather leave this out of the module and I'll be happy to split it into a custom module of my own — or if there's already a better way to achieve this!

Anyway, just thought that others might have use for this feature as well 😄 

(Note: this is not heavily tested yet, but I'm using my fork on one site and so far it seems to work as expected...)