### PR TITLE
Change to the admin layout

### DIFF
--- a/PrivacyWireConfig.php
+++ b/PrivacyWireConfig.php
@@ -50,8 +50,26 @@ class PrivacyWireConfig extends ModuleConfig
         $f = $this->modules->get('InputfieldInteger');
         $f->attr('name', 'version');
         $f->description = $this->_("When you increase the version number, all users have to opt-in again. This version number is saved with the users consent in the cookie.");
-        $f->label = $this->_('Version Number');
+        $f->label = $this->_('Versioning');
         $f->attr('min', 1);
+        $f->columnWidth = 33;
+        $inputfields->add($f);
+
+        // respect "do not track"
+        $f = $this->modules->get('InputfieldCheckbox');
+        $f->attr('name', 'respectDNT');
+        $f->description = $this->_("If enabled, PrivacyWire checks if the users browser sends the DNT-Header. If so, no cookie banner will be shown and the user will be handled like 'Only Necessary Cookies' would be chosen.");
+        $f->label = $this->_('DNT: Do Not Track');
+        $f->checkboxLabel = $this->_('Respect "Do Not Track" Settings from the browser');
+        $f->columnWidth = 33;
+        $inputfields->add($f);
+
+        // ProCache JS Minification
+        $f = $this->modules->get('InputfieldCheckbox');
+        $f->attr('name', 'use_procache_minification');
+        $f->description = $this->_("If enabled, PrivacyWire checks if [ProCache](https://processwire.com/store/pro-cache/#procache-css-js-minification-api) is installed and activated. If so, the javascript files will be minified automatically via ProCache.");
+        $f->label = $this->_('Use ProCache JS Minification (if available)');
+        $f->checkboxLabel = $this->_('Use ProCache JS Minification (if available)');
         $f->columnWidth = 33;
         $inputfields->add($f);
 
@@ -71,20 +89,11 @@ class PrivacyWireConfig extends ModuleConfig
         $f->columnWidth = 33;
         $inputfields->add($f);
 
-        // respect "do not track"
-        $f = $this->modules->get('InputfieldCheckbox');
-        $f->attr('name', 'respectDNT');
-        $f->description = $this->_("If enabled, PrivacyWire checks if the users browser sends the DNT-Header. If so, no cookie banner will be shown and the user will be handled like 'Only Necessary Cookies' would be chosen.");
-        $f->label = $this->_('DNT: Do Not Track');
-        $f->checkboxLabel = $this->_('Respect "Do Not Track" Settings from the browser');
-        $f->columnWidth = 33;
-        $inputfields->add($f);
-
         // fieldset for cookie groups
-        $cookieFieldset = $this->modules->get('InputfieldFieldset');
-        $cookieFieldset->label = $this->_("Cookie Group Labels");
-        $cookieFieldset->description = $this->_("Label of the cookie groups in 'Choose Cookies' window");
-        $inputfields->add($cookieFieldset);
+        $fs = $this->modules->get('InputfieldFieldset');
+        $fs->label = $this->_("Cookie Group Labels");
+        $fs->description = $this->_("Label of the cookie groups in 'Choose Cookies' window");
+        $inputfields->add($fs);
 
         // label for cookie group: necessary
         $f = $this->modules->get('InputfieldText');
@@ -93,7 +102,7 @@ class PrivacyWireConfig extends ModuleConfig
         $f->showIf("cookie_groups=necessary");
         $f->useLanguages = true;
         $f->columnWidth = 25;
-        $cookieFieldset->add($f);
+        $fs->add($f);
 
         // label for cookie group: functional
         $f = $this->modules->get('InputfieldText');
@@ -102,7 +111,7 @@ class PrivacyWireConfig extends ModuleConfig
         $f->showIf("cookie_groups=functional");
         $f->useLanguages = true;
         $f->columnWidth = 25;
-        $cookieFieldset->add($f);
+        $fs->add($f);
 
         // label for cookie group: statistics
         $f = $this->modules->get('InputfieldText');
@@ -111,7 +120,7 @@ class PrivacyWireConfig extends ModuleConfig
         $f->showIf("cookie_groups=statistics");
         $f->useLanguages = true;
         $f->columnWidth = 25;
-        $cookieFieldset->add($f);
+        $fs->add($f);
 
         // label for cookie group: marketing
         $f = $this->modules->get('InputfieldText');
@@ -120,7 +129,7 @@ class PrivacyWireConfig extends ModuleConfig
         $f->showIf("cookie_groups=marketing");
         $f->useLanguages = true;
         $f->columnWidth = 25;
-        $cookieFieldset->add($f);
+        $fs->add($f);
 
         // label for cookie group: external media
         $f = $this->modules->get('InputfieldText');
@@ -129,131 +138,30 @@ class PrivacyWireConfig extends ModuleConfig
         $f->showIf("cookie_groups=external_media");
         $f->useLanguages = true;
         $f->columnWidth = 25;
-        $cookieFieldset->add($f);
+        $fs->add($f);
 
-        // fieldset for contents of the module markup
-        $content = $this->modules->get('InputfieldFieldset');
-        $content->label = $this->_("Banner Content");
-        $inputfields->add($content);
+        // fieldset for banner options
+        $fs = $this->modules->get('InputfieldFieldset');
+        $fs->label = $this->_("Banner");
+        $inputfields->add($fs);
 
         // banner headline (optional)
         $f = $this->modules->get('InputfieldText');
         $f->attr('name', 'content_banner_title');
         $f->description = $this->_("Optional: If empty, no headline will be shown in the banner.");
-        $f->label = $this->_('Banner Title');
+        $f->label = $this->_('Title');
         $f->useLanguages = true;
-        $f->columnWidth = 50;
-        $content->add($f);
+        $f->columnWidth = 100;
+        $fs->add($f);
 
         // banner body copy
         $f = $this->modules->get('InputfieldCKEditor');
         $f->attr('name', 'content_banner_text');
         $f->attr('toolbar', 'Bold, Italic, NumberedList, BulletedList, PWLink, Unlink, PWImage, Table');
-        $f->label = $this->_('Banner Text');
+        $f->label = $this->_('Text');
         $f->useLanguages = true;
-        $f->columnWidth = 50;
-        $content->add($f);
-
-        // privacy policy url
-        $f = $this->modules->get('InputfieldURL');
-        $f->attr('name', 'content_banner_privacy_link');
-        $f->description = $this->_("If you want to output a link to your privacy policy page, add the URL to this page here");
-        $f->label = $this->_('Privacy Policy URL');
-        $f->useLanguages = true;
-        $f->columnWidth = 50;
-        $content->add($f);
-
-        // privacy policy link title
-        $f = $this->modules->get('InputfieldText');
-        $f->attr('name', 'content_banner_privacy_title');
-        $f->label = $this->_('Privacy Policy link title');
-        //$f->showIf = "content_banner_privacy_link!=''";
-        $f->useLanguages = true;
-        $f->columnWidth = 50;
-        $content->add($f);
-
-        // imprint url
-        $f = $this->modules->get('InputfieldURL');
-        $f->attr('name', 'content_banner_imprint_link');
-        $f->description = $this->_("If you want to output a link to your imprint page, add the URL to this page here");
-        $f->label = $this->_('Imprint URL');
-        $f->useLanguages = true;
-        $f->columnWidth = 50;
-        $content->add($f);
-
-        // imprint link title
-        $f = $this->modules->get('InputfieldText');
-        $f->attr('name', 'content_banner_imprint_title');
-        $f->label = $this->_('Imprint link title');
-        //$f->showIf = "content_banner_imprint_link!=''";
-        $f->useLanguages = true;
-        $f->columnWidth = 50;
-        $content->add($f);
-
-        // Button Label: Allow All
-        $f = $this->modules->get('InputfieldText');
-        $f->attr('name', 'content_banner_button_allow_all');
-        $f->label = $this->_('Button Label: Allow All Cookies');
-        $f->useLanguages = true;
-        $f->columnWidth = 33;
-        $content->add($f);
-
-        // Button Label: Allow Necessary
-        $f = $this->modules->get('InputfieldText');
-        $f->attr('name', 'content_banner_button_allow_necessary');
-        $f->label = $this->_('Button Label: Allow Necessary Cookies');
-        $f->useLanguages = true;
-        $f->columnWidth = 33;
-        $content->add($f);
-
-        // Button Label: Choose Cookies
-        $f = $this->modules->get('InputfieldText');
-        $f->attr('name', 'content_banner_button_choose');
-        $f->label = $this->_('Button Label: Choose Cookies');
-        $f->useLanguages = true;
-        $f->columnWidth = 34;
-        $content->add($f);
-
-        // Button Label: Toggle Cookies Options
-        $f = $this->modules->get('InputfieldText');
-        $f->attr('name', 'content_banner_button_toggle');
-        $f->label = $this->_('Button Label: Toggle Cookie Options');
-        $f->useLanguages = true;
-        $f->columnWidth = 33;
-        $content->add($f);
-
-        // Button Label: Save Preferences
-        $f = $this->modules->get('InputfieldText');
-        $f->attr('name', 'content_banner_button_save');
-        $f->label = $this->_('Button Label: Save Preferences');
-        $f->useLanguages = true;
-        $f->columnWidth = 33;
-        $f->value = "";
-        $content->add($f);
-
-        // Textformatter Button Label
-        $f = $this->modules->get('InputfieldText');
-        $f->attr('name', 'textformatter_choose_label');
-        $f->label = $this->_('Textformatter Button label');
-        $f->useLanguages = true;
-        $f->columnWidth = 34;
-        $content->add($f);
-
-        // Saved Message Text
-        $f = $this->modules->get('InputfieldText');
-        $f->attr('name', 'content_banner_save_message');
-        $f->label = $this->_('Save Message');
-        $f->useLanguages = true;
-        $f->columnWidth = 50;
-        $content->add($f);
-
-        // Show another "Accept all" instead of the "Toggle" Button
-        $f = $this->modules->get('InputfieldCheckbox');
-        $f->attr('name', 'content_banner_button_all_instead_toggle');
-        $f->label = $this->_('Choose Window: Show "Accept all" Button instead of "Toggle" Button');
-        $f->checkboxLabel = $this->_('Show "Accept all" Button instead of "Toggle" Button');
-        $f->columnWidth = 50;
-        $content->add($f);
+        $f->columnWidth = 100;
+        $fs->add($f);
 
         // banner show details
         $f = $this->modules->get('InputfieldCheckbox');
@@ -261,7 +169,7 @@ class PrivacyWireConfig extends ModuleConfig
         $f->description = $this->_("If enabled, you will have the possibility to display alternative headline and text elements within the options banner where the user can select the cookies allowed.");
         $f->label = $this->_('Use alternative text and headline for options banner');
         $f->columnWidth = 100;
-        $content->add($f);
+        $fs->add($f);
 
         // banner details headline (optional)
         $f = $this->modules->get('InputfieldText');
@@ -270,8 +178,8 @@ class PrivacyWireConfig extends ModuleConfig
         $f->label = $this->_('Options Banner - Title Details');
         $f->showIf = "content_banner_details_show=1";
         $f->useLanguages = true;
-        $f->columnWidth = 50;
-        $content->add($f);
+        $f->columnWidth = 100;
+        $fs->add($f);
 
         // banner details text
         $f = $this->modules->get('InputfieldCKEditor');
@@ -280,74 +188,8 @@ class PrivacyWireConfig extends ModuleConfig
         $f->showIf = "content_banner_details_show=1";
         $f->label = $this->_('Options Banner - Text Details');
         $f->useLanguages = true;
-        $f->columnWidth = 50;
-        $content->add($f);
-
-        // fieldset for "Ask for consent" markup
-        $content = $this->modules->get('InputfieldFieldset');
-        $content->label = $this->_("Ask for consent");
-        $inputfields->add($content);
-
-        // ask for consent text field
-        $f = $this->modules->get('InputfieldCKEditor');
-        $f->attr('name', 'ask_consent_message');
-        $f->attr('toolbar', 'Bold, Italic, NumberedList, BulletedList, PWLink, Unlink, PWImage, Table');
-        $f->label = $this->_('Text above Button');
-        $f->description = $this->_("You can insert the current cookie category name by using the placeholder {category}.");
-        $f->useLanguages = true;
-        $f->columnWidth = 50;
-        $content->add($f);
-
-        // Ask for consent Button label
-        $f = $this->modules->get('InputfieldText');
-        $f->attr('name', 'ask_content_button_label');
-        $f->label = $this->_('Button Label');
-        $f->description = $this->_("You can insert the current cookie category name by using the placeholder {category}.");
-        $f->useLanguages = true;
-        $f->columnWidth = 50;
-        $content->add($f);
-
-        // fieldset for modifications - have fun ;-)
-        $content = $this->modules->get('InputfieldFieldset');
-        $content->label = $this->_("Modifications");
-        $inputfields->add($content);
-
-
-        // ProCache JS Minification
-        $f = $this->modules->get('InputfieldCheckbox');
-        $f->attr('name', 'use_procache_minification');
-        $f->description = $this->_("If enabled, PrivacyWire checks if [ProCache](https://processwire.com/store/pro-cache/#procache-css-js-minification-api) is installed and activated. If so, the javascript files will be minified automatically via ProCache.");
-        $f->label = $this->_('Use ProCache JS Minification (if available)');
-        $f->checkboxLabel = $this->_('Use ProCache JS Minification (if available)');
-        $f->columnWidth = 33;
-        $content->add($f);
-
-        // add basic css styles or not
-        $f = $this->modules->get('InputfieldCheckbox');
-        $f->attr('name', 'add_basic_css_styling');
-        $f->description = $this->_("If enabled, PrivacyWire will automatically include some very basic css styles to the output.");
-        $f->label = $this->_('CSS: Add basic CSS Styling');
-        $f->checkboxLabel = $this->_('Add basic CSS Styling');
-        $f->columnWidth = 33;
-        $content->add($f);
-
-        // Trigger a custom js function
-        $f = $this->modules->get('InputfieldText');
-        $f->attr('name', 'trigger_custom_js_function');
-        $f->label = $this->_('Trigger a custom js function');
-        $f->description = $this->_("If you want to trigger a custom js function after saving the cookie banner, insert the name of the function here");
-        $f->columnWidth = 34;
-        $content->add($f);
-
-        // Message Timeout
-        $f = $this->modules->get('InputfieldInteger');
-        $f->attr('name', 'messageTimeout');
-        $f->label = $this->_('Timeout of showing the success message');
-        $f->description = $this->_("Time in ms for how long the success message should be visible");
-        $f->columnWidth = 33;
-        $content->add($f);
-
-
+        $f->columnWidth = 100;
+        $fs->add($f);
 
         // banner header tag
         $f = $this->modules->get('InputfieldSelect');
@@ -359,15 +201,15 @@ class PrivacyWireConfig extends ModuleConfig
             "div" => $this->_("<div>"),
         ];
         $f->columnWidth = 33;
-        $content->add($f);
+        $fs->add($f);
 
         // alternate banner template
         $f = $this->modules->get('InputfieldText');
         $f->attr('name', 'alternate_banner_template');
         $f->label = $this->_('Alternate Banner Template');
         $f->description = $this->_("If you want to replace the original banner template (located in site/modules/PrivacyWire/PrivacyWireBanner.php ) insert the alternative file path here (starting from webroot without leading slash )");
-        $f->columnWidth = 34;
-        $content->add($f);
+        $f->columnWidth = 33;
+        $fs->add($f);
 
         // render manually
         $f = $this->modules->get('InputfieldCheckbox');
@@ -375,7 +217,168 @@ class PrivacyWireConfig extends ModuleConfig
         $f->label = $this->_('Render Banner and Header Content Manually');
         $f->description = $this->_("If you want to render PrivacyWire header and banner content manually instead of letting the module render them for you, check this option.");
         $f->notes = $this->_("Use `\$modules->get('PrivacyWire')->renderHeadContent()` to render header tags and `\$modules->get('PrivacyWire')->renderBodyContent()` to render body content.");
-        $content->add($f);
+        $f->columnWidth = 34;
+        $fs->add($f);
+
+       // fieldset for links
+        $fs = $this->modules->get('InputfieldFieldset');
+        $fs->label = $this->_("Links");
+        $inputfields->add($fs);
+
+        // privacy policy url
+        $f = $this->modules->get('InputfieldURL');
+        $f->attr('name', 'content_banner_privacy_link');
+        $f->description = $this->_("If you want to output a link to your privacy policy page, add the URL to this page here");
+        $f->label = $this->_('Privacy Policy URL');
+        $f->useLanguages = true;
+        $f->columnWidth = 50;
+        $fs->add($f);
+
+        // privacy policy link title
+        $f = $this->modules->get('InputfieldText');
+        $f->attr('name', 'content_banner_privacy_title');
+        $f->label = $this->_('Privacy Policy link title');
+        //$f->showIf = "content_banner_privacy_link!=''";
+        $f->useLanguages = true;
+        $f->columnWidth = 50;
+        $fs->add($f);
+
+        // imprint url
+        $f = $this->modules->get('InputfieldURL');
+        $f->attr('name', 'content_banner_imprint_link');
+        $f->description = $this->_("If you want to output a link to your imprint page, add the URL to this page here");
+        $f->label = $this->_('Imprint URL');
+        $f->useLanguages = true;
+        $f->columnWidth = 50;
+        $fs->add($f);
+
+        // imprint link title
+        $f = $this->modules->get('InputfieldText');
+        $f->attr('name', 'content_banner_imprint_title');
+        $f->label = $this->_('Imprint link title');
+        //$f->showIf = "content_banner_imprint_link!=''";
+        $f->useLanguages = true;
+        $f->columnWidth = 50;
+        $fs->add($f);
+
+        // fieldset for buttons
+        $fs = $this->modules->get('InputfieldFieldset');
+        $fs->label = $this->_("Buttons");
+        $inputfields->add($fs);
+
+        // Button Label: Allow All
+        $f = $this->modules->get('InputfieldText');
+        $f->attr('name', 'content_banner_button_allow_all');
+        $f->label = $this->_('Button Label: Allow All Cookies');
+        $f->useLanguages = true;
+        $f->columnWidth = 33;
+        $fs->add($f);
+
+        // Button Label: Allow Necessary
+        $f = $this->modules->get('InputfieldText');
+        $f->attr('name', 'content_banner_button_allow_necessary');
+        $f->label = $this->_('Button Label: Allow Necessary Cookies');
+        $f->useLanguages = true;
+        $f->columnWidth = 33;
+        $fs->add($f);
+
+        // Button Label: Choose Cookies
+        $f = $this->modules->get('InputfieldText');
+        $f->attr('name', 'content_banner_button_choose');
+        $f->label = $this->_('Button Label: Choose Cookies');
+        $f->useLanguages = true;
+        $f->columnWidth = 34;
+        $fs->add($f);
+
+        // Button Label: Toggle Cookies Options
+        $f = $this->modules->get('InputfieldText');
+        $f->attr('name', 'content_banner_button_toggle');
+        $f->label = $this->_('Button Label: Toggle Cookie Options');
+        $f->useLanguages = true;
+        $f->columnWidth = 33;
+        $fs->add($f);
+
+        // Show another "Accept all" instead of the "Toggle" Button
+        $f = $this->modules->get('InputfieldCheckbox');
+        $f->attr('name', 'content_banner_button_all_instead_toggle');
+        $f->label = $this->_('Choose Window: "Accept all" instead of "Toggle"');
+        $f->checkboxLabel = $this->_('Show "Accept all" Button instead of "Toggle" Button');
+        $f->columnWidth = 33;
+        $fs->add($f);
+
+        // Button Label: Save Preferences
+        $f = $this->modules->get('InputfieldText');
+        $f->attr('name', 'content_banner_button_save');
+        $f->label = $this->_('Button Label: Save Preferences');
+        $f->useLanguages = true;
+        $f->columnWidth = 34;
+        $f->value = "";
+        $fs->add($f);
+
+         // Saved Message Text
+        $f = $this->modules->get('InputfieldText');
+        $f->attr('name', 'content_banner_save_message');
+        $f->label = $this->_('Message: Save Confirmation');
+        $f->useLanguages = true;
+        $f->columnWidth = 33;
+        $fs->add($f);
+
+        // Textformatter Button Label
+        $f = $this->modules->get('InputfieldText');
+        $f->attr('name', 'textformatter_choose_label');
+        $f->label = $this->_('Textformatter Button label');
+        $f->useLanguages = true;
+        $f->columnWidth = 33;
+        $fs->add($f);
+
+        // Ask for consent Button label
+        $f = $this->modules->get('InputfieldText');
+        $f->attr('name', 'ask_content_button_label');
+        $f->label = $this->_('Button Label: Ask for consent');
+        $f->description = $this->_("You can insert the current cookie category name by using the placeholder {category}.");
+        $f->useLanguages = true;
+        $f->columnWidth = 34;
+        $fs->add($f);
+
+        // ask for consent text field
+        $f = $this->modules->get('InputfieldCKEditor');
+        $f->attr('name', 'ask_consent_message');
+        $f->attr('toolbar', 'Bold, Italic, NumberedList, BulletedList, PWLink, Unlink, PWImage, Table');
+        $f->label = $this->_('Text above button: Ask for consent');
+        $f->description = $this->_("You can insert the current cookie category name by using the placeholder {category}.");
+        $f->useLanguages = true;
+        $f->columnWidth = 100;
+        $fs->add($f);
+
+        // fieldset for modifications - have fun ;-)
+        $fs = $this->modules->get('InputfieldFieldset');
+        $fs->label = $this->_("Modifications");
+        $inputfields->add($fs);
+
+        // Message Timeout
+        $f = $this->modules->get('InputfieldInteger');
+        $f->attr('name', 'messageTimeout');
+        $f->label = $this->_('Timeout of showing the success message');
+        $f->description = $this->_("Time in ms for how long the success message should be visible");
+        $f->columnWidth = 33;
+        $fs->add($f);
+
+        // add basic css styles or not
+        $f = $this->modules->get('InputfieldCheckbox');
+        $f->attr('name', 'add_basic_css_styling');
+        $f->description = $this->_("If enabled, PrivacyWire will automatically include some very basic css styles to the output.");
+        $f->label = $this->_('CSS: Add basic CSS Styling');
+        $f->checkboxLabel = $this->_('Add basic CSS Styling');
+        $f->columnWidth = 33;
+        $fs->add($f);
+
+        // Trigger a custom js function
+        $f = $this->modules->get('InputfieldText');
+        $f->attr('name', 'trigger_custom_js_function');
+        $f->label = $this->_('Trigger a custom js function');
+        $f->description = $this->_("If you want to trigger a custom js function after saving the cookie banner, insert the name of the function here");
+        $f->columnWidth = 34;
+        $fs->add($f);
 
         return $inputfields;
     }


### PR DESCRIPTION
An attempt to make the admin form more user-friendly by grouping the fields based on elements visible in the front end, rather than on a flow that might be lesss intuitive for a novice. Also changed all fieldset variables to $fs so the fields code could be moved around more easily.
See the comment for a screenshot.