### PR TITLE
Configure inline consent template

### DIFF
--- a/PrivacyWire.module
+++ b/PrivacyWire.module
@@ -152,7 +152,7 @@ class PrivacyWire extends WireData implements Module, ConfigurableModule
         }
 
         return wireRenderFile($filePath, ['module' => $this]);
-		}
+    }
 
     /**
      * Get the PrivacyWire stylesheet as Object with path and url

--- a/PrivacyWire.module
+++ b/PrivacyWire.module
@@ -141,9 +141,18 @@ class PrivacyWire extends WireData implements Module, ConfigurableModule
 
     public function ___renderPrivacyWireConsentBlueprint()
     {
+        $sanitizedAlternateInlineConsentPath = (substr($this->alternate_inline_consent_template, 0, 1) !== "/") ? $this->alternate_inline_consent_template : substr($this->alternate_inline_consent_template, 1);
+
         $filePath = $this->wire('config')->paths->$this . 'PrivacyWireConsentBlueprint.php';
-        return wireRenderFile($filePath, ['module' => $this]);
-    }
+
+        if (
+            !empty($this->alternate_inline_consent_template) &&
+            file_exists($this->wire('config')->paths->root . $sanitizedAlternateInlineConsentPath)) {
+            $filePath = $this->wire('config')->paths->root . $sanitizedAlternateInlineConsentPath;
+        }
+
+		    return wireRenderFile($filePath, ['module' => $this]);
+		}
 
     /**
      * Get the PrivacyWire stylesheet as Object with path and url

--- a/PrivacyWire.module
+++ b/PrivacyWire.module
@@ -151,7 +151,7 @@ class PrivacyWire extends WireData implements Module, ConfigurableModule
             $filePath = $this->wire('config')->paths->root . $sanitizedAlternateInlineConsentPath;
         }
 
-		    return wireRenderFile($filePath, ['module' => $this]);
+        return wireRenderFile($filePath, ['module' => $this]);
 		}
 
     /**

--- a/PrivacyWireConfig.php
+++ b/PrivacyWireConfig.php
@@ -37,6 +37,7 @@ class PrivacyWireConfig extends ModuleConfig
             'ask_content_button_label' => $this->_("Load {category} cookies"),
             'banner_header_tag' => 'div',
             'alternate_banner_template' => '',
+            'alternate_inline_consent_template' => '',
             'render_manually' => false,
             'detect_consents_by_class' => false,
             'output_mode' => 'regular'
@@ -392,6 +393,14 @@ class PrivacyWireConfig extends ModuleConfig
         $f->columnWidth = 33;
         $fs->add($f);
 
-        return $inputfields;
+        // alternate inline consent template
+        $f = $this->modules->get('InputfieldText');
+        $f->attr('name', 'alternate_inline_consent_template');
+        $f->label = $this->_('Alternate Inline Consent Template');
+        $f->description = $this->_("If you want to replace the original inline consent template (located in site/modules/PrivacyWire/PrivacyWireConsentBlueprint.php ) insert the alternative file path here (starting from webroot without leading slash )");
+        $f->columnWidth = 33;
+        $fs->add($f);
+
+			return $inputfields;
     }
 }

--- a/PrivacyWireConfig.php
+++ b/PrivacyWireConfig.php
@@ -401,6 +401,6 @@ class PrivacyWireConfig extends ModuleConfig
         $f->columnWidth = 33;
         $fs->add($f);
 
-			return $inputfields;
+        return $inputfields;
     }
 }


### PR DESCRIPTION
based on the feature request I have posted [here](https://processwire.com/talk/topic/23118-privacywire-cookie-management-async-external-asset-loading/?do=findComment&comment=217537), I though it is time to create my first PR. 

I hope you don't mind and I hope that this feature request hasn't been declined in the past. Actually I didn't read through the 7 pages of the forum.  

There's not much magic - the existing method was just duplicated (I preferred duplication over refactoring to keep it simple and comprehensible). Apart from that the logic is the same as for the banner: if it's configured and available: use the customized template. If not, use the default.

Feel free to edit/adapt/reject :)