### PR TITLE
Add () around if/else short syntax file name in getPrivacyWireCore method

### DIFF
--- a/PrivacyWire.module
+++ b/PrivacyWire.module
@@ -171,7 +171,7 @@ class PrivacyWire extends WireData implements Module, ConfigurableModule
     public function ___getPrivacyWireCore(bool $legacy = false): \StdClass
     {
         $file = new \StdClass;
-        $file->name = "js/PrivacyWire" . ($legacy) ? '_legacy' : '' . ".js";
+        $file->name = "js/PrivacyWire" . ($legacy ? '_legacy' : '') . ".js";
         $file->path = $this->modulePath . $file->name;
         $file->url = $this->moduleUrl . $file->name;
 


### PR DESCRIPTION
The filename of JS script is malformed. By adding parentheses around the if/else statement to check $legacy var, filename is good.