### PR TITLE
Switched `innerText` to `textContent` for accuracy in `updateAllowedElementScript()` of PrivacyWire.js

### DIFF
--- a/src/js/PrivacyWire.js
+++ b/src/js/PrivacyWire.js
@@ -404,8 +404,11 @@ class PrivacyWire {
         if (dataset.src) {
             newEl.src = dataset.src
         }
-        newEl.innerText = el.innerText
-        newEl.id = el.id
+        // textContent is more suitable as innerText may change the value, is limited, costly and slower 
+        // (like introduced <br> elements instead of new lines in inline scripts).
+        // More: https://stackoverflow.com/questions/35213147/difference-between-textcontent-vs-innertext
+        newEl.textContent = el.textContent
+        if (el.id) { newEl.id = el.id} // Do not create an empty ID attribute if no ID exist
         newEl.defer = el.defer
         newEl.async = el.async
         newEl = this.removeUnusedAttributesFromElement(newEl)


### PR DESCRIPTION
`textContent` is more suitable here as `innerText` may change the value, is limited, costly and even slower (although unperceivably).

Like:
- changed newlines into `<br>` elements in inline scripts
- And `newEl.innerText != el.innerText`

More on this: https://stackoverflow.com/questions/35213147/difference-between-textcontent-vs-innertext

Also added condition for transferring IDs in `updateAllowedElementScript()` to keep resulting code just a little bit cleaner.