### PR TITLE
Insert HTML only before the first </head> and the last </body>

### DIFF
--- a/PrivacyWire.module
+++ b/PrivacyWire.module
@@ -93,8 +93,10 @@ class PrivacyWire extends WireData implements Module, ConfigurableModule
 
     public function render(HookEvent $event)
     {
-        $event->return = str_replace("</head>", "{$this->headContent}</head>", $event->return);
-        $event->return = str_replace("</body>", "{$this->bodyContent}</body>", $event->return);
+        $insertion_point = strpos($event->return, "</head>");
+        $event->return = substr($event->return, 0, $insertion_point) . $this->headContent . substr($event->return, $insertion_point);
+        $insertion_point = strrpos($event->return, "</body>");
+        $event->return = substr($event->return, 0, $insertion_point) . $this->bodyContent . substr($event->return, $insertion_point);
     }
 
     public function ___renderPrivacyWireStyles()

--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,26 @@
 {
   "name": "blauequelle/privacywire",
+  "type": "processwire-module",
+  "description": "ProcessWire module, adds management options for GDPR-relevant elements (loading maps, videos etc. only after accepting external media) and cookies.",
+  "keywords": ["processwire", "gdpr", "cookies", "consent"],
+  "homepage": "https://github.com/webworkerJoshua/privacywire/",
   "license": "GPL-3.0",
-  "type": "pw-module",
   "authors": [
     {
       "name": "blauequelle",
       "email": "jk@blauequelle.de"
     }
   ],
+  "extra": {
+    "installer-name": "PrivacyWire"
+  },
   "require": {
-    "wireframe-framework/processwire-composer-installer": "^1.0.0"
+    "php": ">=5.6",
+    "composer/installers": "~1.0"
+  },
+  "config": {
+    "allow-plugins": {
+      "composer/installers": true
+    }
   }
 }


### PR DESCRIPTION
A 3rd party library I used to process CKEditor's output wrapped every block in `<body>` tags and, of course, PrivacyWire dutifully inserted its HTML before each `</body>` tag. I can imagine multiple `</head>` tags too, so it seems safer to just target the first `</head>` tag and the last `</body>` tag.