### PR TITLE
Made the textareas type flexible

### DIFF
--- a/PrivacyWireConfig.php
+++ b/PrivacyWireConfig.php
@@ -4,6 +4,13 @@ class PrivacyWireConfig extends ModuleConfig
 {
     public function __construct()
     {
+        $textarea_type = 'textarea';
+        if ($this->wire()->modules->isInstalled('InputfieldTinyMCE')) {
+          $textarea_type = 'tinymce';
+        } elseif ($this->wire()->modules->isInstalled('InputfieldCkeditor')) {
+          $textarea_type = 'ckeditor';
+        }
+
         $this->add([
             [ // general config
                 'name' => 'privacywire-general',
@@ -128,7 +135,7 @@ class PrivacyWireConfig extends ModuleConfig
                     ],
                     [ // banner body copy
                         'name' => 'content_banner_text',
-                        'type' => 'ckeditor',
+                        'type' => $textarea_type,
                         'label' => $this->_('Text'),
                         //'toolbar' => 'Bold, Italic, NumberedList, BulletedList, PWLink, Unlink, PWImage, Table',
                         'useLanguages' => true,
@@ -153,7 +160,7 @@ class PrivacyWireConfig extends ModuleConfig
                     ],
                     [ // banner details text
                         'name' => 'content_banner_details_text',
-                        'type' => 'ckeditor',
+                        'type' => $textarea_type,
                         'label' => $this->_('Details Text'),
                         //'toolbar' => 'Bold, Italic, NumberedList, BulletedList, PWLink, Unlink, PWImage, Table',
                         'showIf' => "content_banner_details_show=1",
@@ -275,7 +282,7 @@ class PrivacyWireConfig extends ModuleConfig
                     ],
                     [ // ask for consent text field
                         'name' => 'ask_consent_message',
-                        'type' => 'ckeditor',
+                        'type' => $textarea_type,
                         'label' => $this->_('Text above button: Ask for consent'),
                         'description' => $this->_("You can insert the current cookie category name by using the placeholder {category}."),
                         //'toolbar' => 'Bold, Italic, NumberedList, BulletedList, PWLink, Unlink, PWImage, Table',

--- a/package.json
+++ b/package.json
@@ -15,15 +15,15 @@
     "build": "rollup -c --compact"
   },
   "devDependencies": {
-    "@babel/core": "^7.18.6",
-    "@babel/preset-env": "^7.18.6",
-    "@rollup/plugin-babel": "^5.3.1",
-    "postcss": "^8.4.14",
-    "rollup": "^2.75.7",
-    "rollup-pluginutils": "^2.8.2",
+    "@babel/core": "^7.22.5",
+    "@babel/preset-env": "^7.22.5",
+    "@rollup/plugin-babel": "^6.0.3",
+    "@rollup/plugin-terser": "^0.4.3",
+    "postcss": "^8.4.24",
+    "rollup": "^3.25.1",
     "rollup-plugin-copy": "^3.4.0",
     "rollup-plugin-ignore-import": "^1.3.2",
     "rollup-plugin-postcss": "^4.0.2",
-    "rollup-plugin-terser": "^7.0.2"
+    "rollup-pluginutils": "^2.8.2"
   }
 }

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,7 +1,7 @@
 import babel from '@rollup/plugin-babel';
 import postcss from 'rollup-plugin-postcss';
 import ignoreImport from 'rollup-plugin-ignore-import';
-import {terser} from 'rollup-plugin-terser';
+import terser from '@rollup/plugin-terser';
 import copy from 'rollup-plugin-copy';
 
 const production = !process.env.ROLLUP_WATCH;


### PR DESCRIPTION
Added a verification for the 'InputfieldTinyMCE' and 'InputfieldCKEditor' modules before setting the admin fields. If neither is installed, it falls back to plain textareas.