### PR TITLE
Context free formatter

### DIFF
--- a/TextformatterPrivacyWire.module
+++ b/TextformatterPrivacyWire.module
@@ -33,7 +33,14 @@ class TextformatterPrivacyWire extends Textformatter implements Module
         ];
     }
 
-    public function formatValue(Page $page, Field $field, &$str)
+	/**
+	 * Formats the given $str reference.
+	 * Page and Field context are not needed, but the formatter can alternatively also be called by formatValue(Page $page, Field $field, &$value)
+	 * format($$str) internally calls formatValue(Page $page, Field $field, &$value)
+	 * @param mixed $str
+	 * @return void
+	 */
+    public function format(&$str)
     {
         // Replace privacywire-choose-cookies with button element
         $tag_search = $this->open_tag . "privacywire-choose-cookies" . $this->close_tag;

--- a/TextformatterPrivacyWire.module
+++ b/TextformatterPrivacyWire.module
@@ -35,8 +35,9 @@ class TextformatterPrivacyWire extends Textformatter implements Module
 
 	/**
 	 * Formats the given $str reference.
-	 * Page and Field context are not needed, but the formatter can alternatively also be called by formatValue(Page $page, Field $field, &$value)
-	 * format($$str) internally calls formatValue(Page $page, Field $field, &$value)
+	 * Page and Field context are currently not necessary for the formatter to work. 
+	 * The formatter can be called via format(&$str) or formatValue(Page $page, Field $field, &$value)
+	 * formatValue(Page $page, Field $field, &$value) internally calls format(&$str), so the former does not need to be overwritten.
 	 * @param mixed $str
 	 * @return void
 	 */


### PR DESCRIPTION
Changed the implementation from "formatValue" (which requires a reference to Page and Field) to "format" as Page and Field is currently not used. 

"format" should primarily be used for implementing the TextFormatter as it is empty in the base implementation and implicitly called by "formatValue". 

Due to the change it is possible to simply call the TextFormatter by code like so
`$modules->get('TextformatterPrivacyWire')->format($formatterString)
`

while it also still can be called by
`$modules->get('TextformatterPrivacyWire')->formatValue($page, $field, $formatterString)
`