### PR TITLE
Support regular YouTube URL variation with www prefix

### DIFF
--- a/TextformatterPrivacyWire.module
+++ b/TextformatterPrivacyWire.module
@@ -25,7 +25,7 @@ class TextformatterPrivacyWire extends Textformatter implements Module
             'summary' => "PrivacyWire Textformatter to render privacy options via shortcode [[privacywire-choose-cookies]]",
             'author' => 'blaueQuelle',
             'href' => "https://github.com/blaueQuelle/privacywire",
-            'version' => 9,
+            'version' => 10,
             'requires' => [
                 "PHP>=7.2",
                 "ProcessWire>=3.0.110"
@@ -57,7 +57,7 @@ class TextformatterPrivacyWire extends Textformatter implements Module
 
         // Optional: enable PrivacyWire support for embedded media
         if ($this->video_category && (strpos($str, 'www.youtube.com/embed/') !== false || strpos($str, 'www.youtube-nocookie.com/embed/') !== false || strpos($str, 'player.vimeo.com') !== false)) {
-            if (preg_match_all('/\<iframe.*?src=("|\')(?:https?:)\/\/(?:www\.youtube-nocookie|youtube|player\.vimeo)\..*?\1.*?\<\/iframe\>/is', $str, $matches)) {
+            if (preg_match_all('/\<iframe.*?src=("|\')(?:https?:)\/\/(?:(?:www\.)?youtube-nocookie|(?:www\.)?youtube|player\.vimeo)\..*?\1.*?\<\/iframe\>/is', $str, $matches)) {
                 foreach ($matches[0] as $match) {
                     $new_match = str_replace(' src=', ' data-category="' . $this->video_category . '" data-ask-consent=1 data-src=', $match);
                     $str = str_replace($match, $new_match, $str);


### PR DESCRIPTION
Just came across a www prefixed variation of youtube.com URL, which the textformatter didn't account for yet. This PR should fix that.

No version bump for the main module in this PR, by the way; not sure what current convention is. Also it looks like latest master version doesn't have a tag yet, so it's not available via Packagist / Composer :)