### PR TITLE
add default type text/javascript of none is defined to correct function updateAllowedElementScript

### DIFF
--- a/src/js/PrivacyWire.js
+++ b/src/js/PrivacyWire.js
@@ -403,7 +403,7 @@ class PrivacyWire {
         for (const key of Object.keys(dataset)) {
             newEl.dataset[key] = el.dataset[key]
         }
-        newEl.type = dataset.type
+        newEl.type = dataset.type ?? 'text/javascript'
         if (dataset.src) {
             newEl.src = dataset.src
         }


### PR DESCRIPTION
An update to fix for issue #33 - Scripts without type="text/javascript" gets initialized as type="undefined" and doesn't fire Previous fix added fallback only to `updateAllowedElementOther()`, but it was needed in `updateAllowedElementScript()` too.