### PR TITLE
Support data-poster attribute

### DIFF
--- a/src/js/PrivacyWire.js
+++ b/src/js/PrivacyWire.js
@@ -424,7 +424,7 @@ class PrivacyWire {
         el.type = dataset.type ?? 'text/javascript'
         el.src = dataset.src
         el.srcset = dataset.srcset
-        el.srcset = dataset.poster
+        el.poster = dataset.poster
         this.removeUnusedAttributesFromElement(el)
     }
 

--- a/src/js/PrivacyWire.js
+++ b/src/js/PrivacyWire.js
@@ -424,6 +424,7 @@ class PrivacyWire {
         el.type = dataset.type ?? 'text/javascript'
         el.src = dataset.src
         el.srcset = dataset.srcset
+        el.srcset = dataset.poster
         this.removeUnusedAttributesFromElement(el)
     }
 
@@ -433,6 +434,7 @@ class PrivacyWire {
         el.removeAttribute("data-category")
         el.removeAttribute("data-src")
         el.removeAttribute("data-srcset")
+        el.removeAttribute("data-poster")
         el.removeAttribute("data-type")
         el.classList.remove("require-consent")
         return el


### PR DESCRIPTION
Added data-poster to allowed elements to update data-poster attribut. 

Explanation:
I use PrivacyWire with the InstagramMediaDisplay module, among others, to initially block files and only load them when the user agrees.  Unfortunately, I have not found a way to block the poster attribute in a < video > element. I hope this is possible with this change?

Could you @webworkerJoshua  please check this and adopt it if necessary?