### PR TITLE
Fix: Process all disallowed elements instead of stopping after first

### DIFF
--- a/src/js/PrivacyWire.js
+++ b/src/js/PrivacyWire.js
@@ -432,7 +432,7 @@ class PrivacyWire {
         }
         if (!allowed) {
           this.updateDisallowedElement(el);
-          return;
+          continue;
         }
         this.updateAllowedElement(el);
       }


### PR DESCRIPTION
## Summary
- Fix bug in `checkElementsWithRequiredConsent()` where early `return` caused loop to exit after processing first disallowed element
- Change `return` to `continue` to ensure all blocked elements get consent messages
- Resolves issue where only first element with denied consent category would display ask-consent message

## Problem
When multiple elements on a page require the same denied consent category (e.g., iframe + script both needing `external_media`), only the first element displays a consent message. Subsequent elements are silently blocked without any user-facing consent request.

## Root Cause
**Bug in `checkElementsWithRequiredConsent()` method (line 435)**
```javascript
// Buggy code
if (!allowed) {
  this.updateDisallowedElement(el);
  return; // ← Exits entire loop
}
```

## Solution
```javascript
// Fixed code  
if (!allowed) {
  this.updateDisallowedElement(el);
  continue; // ← Process next element
}
```

## Test Results ✅
1. **Page Load**: Both iframe and script are properly blocked
2. **Consent Message**: Displayed adjacent to iframe with correct category text  
3. **Button Click**: Iframe loads, consent message removed, localStorage updated
4. **Script Execution**: Associated scripts load and execute properly

## Related Issue
Fixes #45

🤖 Generated with [Claude Code](https://claude.ai/code)